### PR TITLE
Add support for typescript directives that use templateUrl as variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,18 +52,18 @@ function proxy(fn, context) {
 
 function transform(basePath, template) {
 
-    var templateUrlRegex = /templateUrl\:[^\'\"]*(\'|\")([^\'\"]+)(\'|\")/gm;
+    var templateUrlRegex = /templateUrl\s*([\:\=])[^\'\"]*(\'|\")([^\'\"]+)(\'|\")/gm;
 
     var matches, templateContent, templateInline, templatePath;
     while ((matches = templateUrlRegex.exec(template)) !== null) {
 
-        templatePath = path.join(basePath, matches[2]);
+        templatePath = path.join(basePath, matches[3]);
 
         if (fileExistsSync(templatePath)) {
 
             templateContent = extractTemplateUrl(templatePath);
 
-            templateInline = getTemplateInline(templateContent, {
+            templateInline = getTemplateInline(matches[1], templateContent, {
                 collapseWhitespace: true
             });
 
@@ -86,10 +86,10 @@ function extractTemplateUrl(templateUrlPath) {
     return fs.readFileSync(templateUrlPath, 'utf8');
 }
 
-function getTemplateInline(content, options) {
+function getTemplateInline(sign, content, options) {
     var template = minify(content, options);
     var templateEscaped = stringEscape(template);
-    return 'template: \'' + templateEscaped + '\'';
+    return 'template' + sign + ' \'' + templateEscaped + '\'';
 }
 
 function replaceTemplateUrl(index, length, content, templateInline) {


### PR DESCRIPTION
I think You could add support for directives written in typescript where templateUrl is used as class variable:

`export class MyDirective {`
 `public link: (scope: IMyScope, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => void;`
 `public templateUrl = 'path/to/file.html';`
 `// ...`
`}`

which is compiled to something like that:

`var SomeDirective = (function () {`
    `function SomeDirective() {`
        `var _this = this;`
        `this.templateUrl = 'path/to/file.html';`
        `this.link = function (scope, element, attrs) {`
        `}`
    `}`
`});`
